### PR TITLE
fix: remove obsolete render_ahead_of_time option

### DIFF
--- a/hm/wms/hypr/hyprland.nix
+++ b/hm/wms/hypr/hyprland.nix
@@ -242,7 +242,6 @@ in
             animate_manual_resizes = true;
             animate_mouse_windowdragging = true;
             enable_swallow = true;
-            render_ahead_of_time = false;
             disable_hyprland_logo = true;
             focus_on_activate = true;
           };


### PR DESCRIPTION
removed in hyprland 0.50.0 release
https://github.com/hyprwm/Hyprland/releases/tag/v0.50.0